### PR TITLE
fix(plugin): app logo on loading page supports dark mode

### DIFF
--- a/plugins/vite-plugin-blocklet/libs/loading.js
+++ b/plugins/vite-plugin-blocklet/libs/loading.js
@@ -112,11 +112,18 @@ function generateHtml({ color, image }) {
   <script>
     (() => {
       const loadingImage = document.getElementById('loadingImage');
-      if (window?.blocklet?.appLogo) {
-        loadingImage.src = window.blocklet.appLogo;
-      } else {
-        loadingImage.src = "${image}";
+      const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      
+      let logo = "${image}"; 
+
+      if (window?.blocklet) {
+        const { appLogo, appLogoDark } = window.blocklet;
+        if (appLogo) {
+          logo = isDark && appLogoDark ? appLogoDark : appLogo;
+        }
       }
+
+      loadingImage.src = logo;
     })();
   </script>`;
 }


### PR DESCRIPTION
### Relates Issue

<!-- Please use words like `fixes`, `closes`, `resolves`, `relates` to link issues. In principle, all PR should be associated with an Issue -->

- relates https://team.arcblock.io/task/task/582001899801149440

### Main changes

1. 改进了：loading 页面的 app logo 支持 dark 模式

### Screenshots

<!-- If the change is related to UI, both `cli` and `web` should take screenshots -->

- dark mode

<img width="1244" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/dd45c2cf-01ad-4e04-8fd1-0ba8903906fb" />

- light mode 

<img width="814" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/b20813aa-d235-451d-9097-78a6453b96d2" />

### Check list

- [x] Project create by create-blocklet can work with `npm run dev`
- [x] Project create by create-blocklet can work with `npm run deploy`
- [x] Project create by create-blocklet can work with `npm run upload`
- [x] If a new version need to be publish, make sure you have run `npm run bump-version` command
